### PR TITLE
Add UPLOAD_OPERA_EXTENSION_MAX_WAIT_TIME

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const puppeteer = require('puppeteer')
+const maxWaitTIme = process.env.UPLOAD_OPERA_EXTENSION_MAX_WAIT_TIME || 30000;
 
 async function uploadOperaExtension (options) {
   const debugModeEnabled = Boolean(process.env.DEBUG_UPLOAD_OPERA_EXTENSION)
@@ -8,33 +9,33 @@ async function uploadOperaExtension (options) {
 
   try {
     // Directly go to the extension page - the browser will be redirected to the auth page and back once the login succeeded
-    await page.goto(`https://addons.opera.com/developer/package/${options.extensionId}/`)
+    await page.goto(`https://addons.opera.com/developer/package/${options.extensionId}/`, { timeout: maxWaitTIme })
 
     // Perform login
-    await page.type('input[name=email]', options.email)
-    await page.type('input[name=password]', options.password)
-    await page.click('button[type=submit]')
+    await page.type('input[name=email]', options.email, { timeout: maxWaitTIme })
+    await page.type('input[name=password]', options.password, { timeout: maxWaitTIme })
+    await page.click('button[type=submit]', { timeout: maxWaitTIme })
 
     // Wait for, and then click, "Versions"
-    await page.waitForSelector('ul.nav .uib-tab:nth-child(2) a')
-    await page.click('ul.nav .uib-tab:nth-child(2) a')
+    await page.waitForSelector('ul.nav .uib-tab:nth-child(2) a', { timeout: maxWaitTIme })
+    await page.click('ul.nav .uib-tab:nth-child(2) a', { timeout: maxWaitTIme })
 
     // Wait for file uploader, and then select the zip file
-    await page.waitForSelector('file-upload[on-upload*=upgradeAddon] input[type=file]')
-    await page.$('file-upload[on-upload*=upgradeAddon] input[type=file]').then(i => i.uploadFile(options.zipPath))
+    await page.waitForSelector('file-upload[on-upload*=upgradeAddon] input[type=file]', { timeout: maxWaitTIme })
+    await page.$('file-upload[on-upload*=upgradeAddon] input[type=file]', { timeout: maxWaitTIme }).then(i => i.uploadFile(options.zipPath))
 
     // Upload it
-    await page.click('upload-label')
-    await page.waitForSelector('ol.breadcrumb')
+    await page.click('upload-label', { timeout: maxWaitTIme })
+    await page.waitForSelector('ol.breadcrumb', { timeout: maxWaitTIme })
 
     // Wait for file to be uploaded, or for an error to appear
     try {
-      await page.waitForSelector('[ng-click="submitForModeration()"]')
+      await page.waitForSelector('[ng-click="submitForModeration()"]', { timeout: maxWaitTIme })
     } catch (_) {
       let errorText
 
       try {
-        errorText = await page.evaluate(() => document.querySelector('flash-message div.alert span.ng-scope').innerText)
+        errorText = await page.evaluate(() => document.querySelector('flash-message div.alert span.ng-scope').innerText, { timeout: maxWaitTIme })
       } catch (_) {
         errorText = 'Unknown error occurred while uploading extension'
       }
@@ -43,7 +44,7 @@ async function uploadOperaExtension (options) {
     }
 
     // Submit for moderation
-    await page.click('[ng-click="submitForModeration()"]')
+    await page.click('[ng-click="submitForModeration()"]', { timeout: maxWaitTIme })
   } finally {
     if (!debugModeEnabled) await browser.close()
   }


### PR DESCRIPTION
Add optional configuration variable to provide max wait time for event. Useful, when for some reason it's needed to wait a bit more for opera page to load (e.g. in my case I was using debug option enabled and entering captcha manually)